### PR TITLE
Helderop_edits

### DIFF
--- a/esda/07_global_spatial_autocorrelation.ipynb
+++ b/esda/07_global_spatial_autocorrelation.ipynb
@@ -1128,7 +1128,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getis Ord $G$"
+    "## Getis Ord $G$\n"
+    "\n"
+    "$$G_i = \\frac{\\sum_j w_{i,j} x_j}{\\sum_j x_i}$$"
    ]
   },
   {

--- a/esda/07_global_spatial_autocorrelation.ipynb
+++ b/esda/07_global_spatial_autocorrelation.ipynb
@@ -1128,8 +1128,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getis Ord $G$\n"
-    "\n"
+    "## Getis Ord $G$\n",
+    "\n",
     "$$G_i = \\frac{\\sum_j w_{i,j} x_j}{\\sum_j x_i}$$"
    ]
   },


### PR DESCRIPTION
Added the Getis Ord G equation to the 07_global_spatial_autocorrelation module to match the format used for the Moran's I equation (already present) earlier in the same .ipynb.
